### PR TITLE
Logger can be overridden from external sources

### DIFF
--- a/ipfilter.go
+++ b/ipfilter.go
@@ -55,21 +55,7 @@ type Options struct {
 	BlockByDefault bool
 
 	Logger interface {
-		Fatal(v ...interface{})
-		Fatalf(format string, v ...interface{})
-		Fatalln(v ...interface{})
-		Flags() int
-		Output(calldepth int, s string) error
-		Panic(v ...interface{})
-		Panicf(format string, v ...interface{})
-		Panicln(v ...interface{})
-		Prefix() string
-		Print(v ...interface{})
 		Printf(format string, v ...interface{})
-		Println(v ...interface{})
-		SetFlags(flag int)
-		SetOutput(w io.Writer)
-		SetPrefix(prefix string)
 	}
 }
 


### PR DESCRIPTION
Allows logger to be overriden with an external logger.

```golang
  flags :=  log.Ldate | log.Ltime | log.LUTC
  logger := log.New(os.Stdout, "[stuff] ", flags)

  ipFilter,err := ipfilter.New(ipfilter.Options{
    AllowedIPs: configuration.IPWhiteList,
    BlockByDefault: true,
    Logger: logger,
  })
```