### PR TITLE
rename geoip to iploc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ go get github.com/jpillora/ipfilter
 * Thread-safe
 * IPv4 / IPv6 support
 * Subnet support
-* Location filtering (via [phuslu/geoip](https://github.com/phuslu/geoip)
+* Location filtering (via [phuslu/iploc](https://github.com/phuslu/iploc)
 * Simple HTTP middleware
 
 ### Usage

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jpillora/ipfilter
 go 1.13
 
 require (
-	github.com/phuslu/geoip v1.0.20200217
+	github.com/phuslu/iploc v1.0.20200807
 	github.com/stretchr/testify v1.4.0
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/phuslu/geoip v1.0.20200217 h1:pap5n0dO6f2HUOXKGW0OrG0Y9OlxN0uC+XKMvziUm6g=
-github.com/phuslu/geoip v1.0.20200217/go.mod h1:2z3izHYc+bwW7j5pyvtXG8N+I9Q87XnZfULO6lN9NhA=
+github.com/phuslu/iploc v1.0.20200807 h1:LIBm2Y9l5zmUvnJhQgMcLZ0iVwuG+5/L6AgbMwSOpE4=
+github.com/phuslu/iploc v1.0.20200807/go.mod h1:Q/0VX0txvbxekt4NhWIi3Q3eyZ139lHhnlzvDxyXhuc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/ipfilter.go
+++ b/ipfilter.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/phuslu/geoip"
+	"github.com/phuslu/iploc"
 	"github.com/tomasen/realip"
 )
 
@@ -240,7 +240,7 @@ func IPToCountry(ipstr string) string {
 //Returns an empty string when cannot determine country.
 func NetIPToCountry(ip net.IP) string {
 	if ip != nil {
-		return string(geoip.Country(ip))
+		return string(iploc.Country(ip))
 	}
 	return ""
 }


### PR DESCRIPTION
MaxMind Crop. said my repo is a trademark infringement
```
Hi Phus,

I hope this email finds you well.

We recently came across your GitHub repository (https://github.com/phuslu/geoip/) and noticed that it is using one of MaxMind's (www.maxmind.com) trademark, "GeoIP® ". Your use of GeoIP in your repository is an unapproved use of our GeoIP trademark. With that being said, would you please remove the word GeoIP from your repository name and the files contained within the repository?

I understand this change may take some time, but can you kindly confirm receipt of this email?

In addition, please feel free to reach out if you have any questions. We appreciate your understanding in this matter.
```

so I rename it to iploc and release a new tag